### PR TITLE
chroe: bump sdk package

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@mento-protocol/mento-sdk": "2.0.0-beta.3",
+    "@mento-protocol/mento-sdk": "2.0.0-beta.4",
     "@nestjs/cache-manager": "2.3.0",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@mento-protocol/mento-sdk':
-        specifier: 2.0.0-beta.3
-        version: 2.0.0-beta.3(ethers@6.13.4)
+        specifier: 2.0.0-beta.4
+        version: 2.0.0-beta.4(ethers@6.13.4)
       '@nestjs/cache-manager':
         specifier: 2.3.0
         version: 2.3.0(@nestjs/common@10.4.11(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.11(@nestjs/common@10.4.11(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.11)(reflect-metadata@0.2.2)(rxjs@7.8.1))(cache-manager@5.7.6)(rxjs@7.8.1)
@@ -464,8 +464,8 @@ packages:
   '@mento-protocol/mento-core-ts@0.2.3':
     resolution: {integrity: sha512-Fjj0t2a6xqpHTbhfafioqjkY9ZDBsq3oy/DkRizihDI2zul/PFQJfQwyy7WDSSc/cNAflevBeSJyqTPTv9HD/Q==}
 
-  '@mento-protocol/mento-sdk@2.0.0-beta.3':
-    resolution: {integrity: sha512-N2op5GKXhF8Q9Nd+fDxmxSOEHPBQe0wbHZYuP6gIL/vADNoO4Wfxs5cSgO+d2vO+2Ov4s9hP2cHsLX1aRmjGHw==}
+  '@mento-protocol/mento-sdk@2.0.0-beta.4':
+    resolution: {integrity: sha512-guJOQApQIjzPjKdRjDSsr0I7tauf0VmioDgb4rO8G3PZCBtKDP4jb6fMVJ+/WqGRQtX31T+5/LraG7Vf7l6FWw==}
     engines: {node: '>=18', pnpm: '>=9'}
     peerDependencies:
       ethers: ^6.13.4
@@ -3483,7 +3483,7 @@ snapshots:
 
   '@mento-protocol/mento-core-ts@0.2.3': {}
 
-  '@mento-protocol/mento-sdk@2.0.0-beta.3(ethers@6.13.4)':
+  '@mento-protocol/mento-sdk@2.0.0-beta.4(ethers@6.13.4)':
     dependencies:
       '@mento-protocol/mento-core-ts': 0.2.3
       bignumber.js: 9.1.2


### PR DESCRIPTION
# Description

Update to use the latest beta SDK package. [This version](https://github.com/mento-protocol/mento-sdk/commit/748f7513b170c096c06666d83f0d217044bf679d) adds retry logic with exponential backoff to get around EAI_AGAIN errors from Infura  

## Other changes

- None

## Tested

-  API functions as expected but logs will be monitored for instances of the error
