### PR TITLE
feat: add priming for PriceFetcherService in CacheWarmerService

### DIFF
--- a/src/common/services/cache-warmer.service.ts
+++ b/src/common/services/cache-warmer.service.ts
@@ -6,6 +6,7 @@ import { ReserveService } from '@api/reserve/services/reserve.service';
 import { StablecoinsService } from '@api/stablecoins/stablecoins.service';
 import { Cache } from 'cache-manager';
 import { CACHE_TTL } from '../constants';
+import { PriceFetcherService } from './price-fetcher.service';
 
 /**
  * Warms the cache for reserve and stablecoins endpoints on a schedule.
@@ -20,6 +21,7 @@ export class CacheWarmerService implements OnModuleInit {
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
     private readonly reserveService: ReserveService,
     private readonly stablecoinsService: StablecoinsService,
+    private readonly priceFetcherService: PriceFetcherService,
   ) {}
 
   @Cron(CronExpression.EVERY_HOUR)
@@ -27,6 +29,8 @@ export class CacheWarmerService implements OnModuleInit {
     this.logger.log('Starting cache warm-up...');
 
     try {
+      await this.primePriceFetcher();
+
       await Promise.all([this.warmReserveEndpoints(), this.warmStablecoinsEndpoints()]);
 
       this.logger.log('Cache warm-up completed successfully');
@@ -38,6 +42,22 @@ export class CacheWarmerService implements OnModuleInit {
   async onModuleInit() {
     this.logger.log('Initializing cache warmer...');
     await this.warmCache();
+  }
+
+  /**
+   * Prime the price fetcher service to ensure it's ready to use.
+   * This is useful for ensuring that the price fetcher service is ready to use
+   * and to avoid the initial delay when the first price fetch is made.
+   */
+  private async primePriceFetcher() {
+    try {
+      // Fetch a known ticker like BTC to "warm up" the connection
+      this.logger.log('Priming PriceFetcherService...');
+      await this.priceFetcherService.getPrice('BTC');
+      this.logger.log('PriceFetcherService primed successfully');
+    } catch (err) {
+      this.logger.warn(`Failed to prime price fetcher (it should retry automatically anyway). Error: ${err.message}`);
+    }
   }
 
   /**


### PR DESCRIPTION
# Description

When fetching prices from coinmarket cap the first call consistently fails with a connection timeout. This is likely due to some DNS resolution delay or some transient network issue. 
![image](https://github.com/user-attachments/assets/132061d5-8dcd-4a6c-964e-6d17482fa916)

This does not impact the API as external calls use retries, and subsequent calls always pass. But to help prevent this, this PR adds a call to the price fetcher service, during cache warmup to "prime" the service and potentially avoid any issues.

## Other changes

None

## Tested

Verified app still functions as intended but logs will need to be monitored to ensure the change stops the issue.
