### PR TITLE
feat: standardize caching & add manual invalidation

### DIFF
--- a/src/api/cache/cache.controller.ts
+++ b/src/api/cache/cache.controller.ts
@@ -1,0 +1,71 @@
+import { Controller, Get, Delete, Param } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiProperty } from '@nestjs/swagger';
+import { CacheService } from '@common/services/cache.service';
+
+class CacheClearResponse {
+  @ApiProperty({ example: true })
+  success: boolean;
+
+  @ApiProperty({ example: ['reserve-holdings', 'stablecoins'] })
+  clearedKeys?: string[];
+
+  @ApiProperty({ example: 'Cache key not found' })
+  message?: string;
+}
+
+@ApiTags('cache')
+@Controller('api/v1/cache')
+export class CacheController {
+  constructor(private readonly cacheService: CacheService) {}
+
+  @Delete('clear-all')
+  @ApiOperation({ summary: 'Clear all cache keys' })
+  @ApiResponse({
+    status: 200,
+    description: 'All cache keys have been cleared',
+    type: CacheClearResponse,
+  })
+  async clearAllCache(): Promise<CacheClearResponse> {
+    const result = await this.cacheService.clearAllCache();
+    return {
+      success: result.success,
+      clearedKeys: result.clearedKeys,
+    };
+  }
+
+  @Delete('clear/:key')
+  @ApiOperation({ summary: 'Clear a specific cache key' })
+  @ApiResponse({
+    status: 200,
+    description: 'Cache key cleared successfully',
+    type: CacheClearResponse,
+  })
+  async clearCacheKey(@Param('key') key: string): Promise<CacheClearResponse> {
+    const knownKeys = this.cacheService.getKnownCacheKeys();
+
+    if (!knownKeys.includes(key)) {
+      return {
+        success: false,
+        message: `Unknown cache key. Available keys: ${knownKeys.join(', ')}`,
+      };
+    }
+
+    const success = await this.cacheService.clearCacheKey(key);
+    return {
+      success,
+      clearedKeys: success ? [key] : [],
+    };
+  }
+
+  @Get('keys')
+  @ApiOperation({ summary: 'Get all available cache keys' })
+  @ApiResponse({
+    status: 200,
+    description: 'List of all available cache keys',
+  })
+  getAvailableCacheKeys() {
+    return {
+      keys: this.cacheService.getKnownCacheKeys(),
+    };
+  }
+}

--- a/src/api/cache/cache.module.ts
+++ b/src/api/cache/cache.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CommonModule } from '@common/common.module';
+import { CacheController } from './cache.controller';
+
+@Module({
+  imports: [CommonModule],
+  controllers: [CacheController],
+})
+export class CacheModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,11 +6,13 @@ import { CommonModule } from '@common/common.module';
 import { StablecoinsModule } from '@api/stablecoins/stablecoins.module';
 import { ReserveModule } from '@api/reserve/reserve.module';
 import { HealthModule } from './api/health/health.module';
+import { CacheModule as ApiCacheModule } from './api/cache/cache.module';
 import { LoggerModule } from 'nestjs-pino';
 import { getLocalPinoConfig, getProductionPinoConfig } from './config/logger.config';
 import { SentryModule } from '@sentry/nestjs/setup';
 import { APP_FILTER } from '@nestjs/core';
 import { SentryGlobalFilter } from '@sentry/nestjs/setup';
+import { CACHE_CONFIG } from './common/config/cache.config';
 
 @Module({
   imports: [
@@ -18,12 +20,13 @@ import { SentryGlobalFilter } from '@sentry/nestjs/setup';
     ScheduleModule.forRoot(),
     CacheModule.register({
       isGlobal: true,
-      ttl: 4500000,
+      ttl: CACHE_CONFIG.TTL.DEFAULT,
     }),
     CommonModule,
     StablecoinsModule,
     ReserveModule,
     HealthModule,
+    ApiCacheModule,
     LoggerModule.forRoot(process.env.NODE_ENV === 'production' ? getProductionPinoConfig() : getLocalPinoConfig()),
   ],
   providers: [{ provide: APP_FILTER, useClass: SentryGlobalFilter }, CacheWarmerService],

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -4,6 +4,7 @@ import { MentoService } from './services/mento.service';
 import { ExchangeRatesService } from './services/exchange-rates.service';
 import { PriceFetcherService } from './services/price-fetcher.service';
 import { ChainProvidersService } from './services/chain-provider.service';
+import { CacheService } from './services/cache.service';
 
 @Global()
 @Module({
@@ -12,7 +13,7 @@ import { ChainProvidersService } from './services/chain-provider.service';
       isGlobal: true,
     }),
   ],
-  providers: [MentoService, ExchangeRatesService, PriceFetcherService, ChainProvidersService],
-  exports: [MentoService, ExchangeRatesService, PriceFetcherService, ChainProvidersService],
+  providers: [MentoService, ExchangeRatesService, PriceFetcherService, ChainProvidersService, CacheService],
+  exports: [MentoService, ExchangeRatesService, PriceFetcherService, ChainProvidersService, CacheService],
 })
 export class CommonModule {}

--- a/src/common/config/cache.config.ts
+++ b/src/common/config/cache.config.ts
@@ -1,0 +1,26 @@
+/**
+ * Centralized cache configuration for the application
+ */
+export const CACHE_CONFIG = {
+  /**
+   * Standard TTLs in milliseconds
+   */
+  TTL: {
+    DEFAULT: 5 * 60 * 1000, // 5 minutes
+    SHORT: 1 * 60 * 1000, // 1 minute
+    MEDIUM: 15 * 60 * 1000, // 15 minutes
+    LONG: 60 * 60 * 1000, // 1 hour
+    WARM: 3 * 60 * 60 * 1000 + 15 * 60 * 1000, // 3h15m (warming TTL)
+  },
+  /**
+   * Cache key prefix to avoid naming collisions
+   */
+  KEY_PREFIX: 'mento-analytics:',
+};
+
+/**
+ * Helper function to ensure cache keys have the proper prefix
+ */
+export const createCacheKey = (key: string): string => {
+  return key.startsWith(CACHE_CONFIG.KEY_PREFIX) ? key : `${CACHE_CONFIG.KEY_PREFIX}${key}`;
+};

--- a/src/common/constants/cache-keys.constants.ts
+++ b/src/common/constants/cache-keys.constants.ts
@@ -1,0 +1,39 @@
+import { createCacheKey } from '../config/cache.config';
+
+/**
+ * Raw key names for reference
+ */
+const RAW_KEYS = {
+  RESERVE_HOLDINGS: 'reserve-holdings',
+  RESERVE_COMPOSITION: 'reserve-composition',
+  RESERVE_HOLDINGS_GROUPED: 'reserve-holdings-grouped',
+  RESERVE_STATS: 'reserve-stats',
+  STABLECOINS: 'stablecoins',
+};
+
+/**
+ * Cache keys with prefix applied
+ */
+export const CACHE_KEYS = {
+  RESERVE_HOLDINGS: createCacheKey(RAW_KEYS.RESERVE_HOLDINGS),
+  RESERVE_COMPOSITION: createCacheKey(RAW_KEYS.RESERVE_COMPOSITION),
+  RESERVE_HOLDINGS_GROUPED: createCacheKey(RAW_KEYS.RESERVE_HOLDINGS_GROUPED),
+  RESERVE_STATS: createCacheKey(RAW_KEYS.RESERVE_STATS),
+  STABLECOINS: createCacheKey(RAW_KEYS.STABLECOINS),
+};
+
+/**
+ * Array of all known cache keys for iteration
+ */
+export const ALL_CACHE_KEYS = Object.values(CACHE_KEYS);
+
+/**
+ * Mapping raw keys to prefixed keys for backward compatibility
+ */
+export const RAW_TO_PREFIXED_MAP: Record<string, string> = {
+  [RAW_KEYS.RESERVE_HOLDINGS]: CACHE_KEYS.RESERVE_HOLDINGS,
+  [RAW_KEYS.RESERVE_COMPOSITION]: CACHE_KEYS.RESERVE_COMPOSITION,
+  [RAW_KEYS.RESERVE_HOLDINGS_GROUPED]: CACHE_KEYS.RESERVE_HOLDINGS_GROUPED,
+  [RAW_KEYS.RESERVE_STATS]: CACHE_KEYS.RESERVE_STATS,
+  [RAW_KEYS.STABLECOINS]: CACHE_KEYS.STABLECOINS,
+};

--- a/src/common/constants/index.ts
+++ b/src/common/constants/index.ts
@@ -1,1 +1,1 @@
-export const CACHE_TTL = 195 * 60 * 1000; // 3 hours 15 minutes in milliseconds
+export * from './cache-keys.constants';

--- a/src/common/services/cache.service.ts
+++ b/src/common/services/cache.service.ts
@@ -1,0 +1,121 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
+import { ALL_CACHE_KEYS, RAW_TO_PREFIXED_MAP } from '@common/constants';
+import { CACHE_CONFIG, createCacheKey } from '@common/config/cache.config';
+
+@Injectable()
+export class CacheService {
+  private readonly logger = new Logger(CacheService.name);
+
+  constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
+
+  /**
+   * Get value from cache with proper key handling
+   */
+  async get<T>(key: string): Promise<T | undefined> {
+    const processedKey = this.processKey(key);
+    try {
+      return await this.cacheManager.get<T>(processedKey);
+    } catch (error) {
+      this.logger.error(`Failed to get cache for key '${processedKey}'`, error);
+      return undefined;
+    }
+  }
+
+  /**
+   * Set value in cache with consistent TTL handling
+   */
+  async set<T>(key: string, value: T, ttl = CACHE_CONFIG.TTL.DEFAULT): Promise<void> {
+    const processedKey = this.processKey(key);
+    try {
+      await this.cacheManager.set(processedKey, value, ttl);
+      this.logger.debug(`Cache set for key '${processedKey}'`);
+    } catch (error) {
+      this.logger.error(`Failed to set cache for key '${processedKey}'`, error);
+    }
+  }
+
+  /**
+   * Clear a specific cache key
+   */
+  async clearCacheKey(key: string): Promise<boolean> {
+    const processedKey = this.processKey(key);
+    try {
+      await this.cacheManager.del(processedKey);
+      this.logger.log(`Cache key '${processedKey}' cleared successfully`);
+
+      // Try to clear the legacy key version too for backward compatibility
+      if (processedKey.includes(CACHE_CONFIG.KEY_PREFIX)) {
+        const legacyKey = processedKey.replace(CACHE_CONFIG.KEY_PREFIX, '');
+        await this.cacheManager.del(legacyKey);
+      }
+
+      return true;
+    } catch (error) {
+      this.logger.error(`Failed to clear cache key '${processedKey}'`, error);
+      return false;
+    }
+  }
+
+  /**
+   * Clear all cache keys
+   */
+  async clearAllCache(): Promise<{ success: boolean; clearedKeys: string[] }> {
+    const clearedKeys: string[] = [];
+    let hasError = false;
+
+    // Clear new prefixed keys
+    await Promise.all(
+      ALL_CACHE_KEYS.map(async (key) => {
+        try {
+          await this.cacheManager.del(key);
+          clearedKeys.push(key);
+        } catch (error) {
+          hasError = true;
+          this.logger.error(`Failed to clear cache key '${key}'`, error);
+        }
+      }),
+    );
+
+    // Also try to clear legacy non-prefixed keys
+    for (const rawKey of Object.keys(RAW_TO_PREFIXED_MAP)) {
+      try {
+        await this.cacheManager.del(rawKey);
+        clearedKeys.push(rawKey);
+      } catch {
+        // No need to log errors for legacy keys
+      }
+    }
+
+    return {
+      success: !hasError,
+      clearedKeys,
+    };
+  }
+
+  /**
+   * Get all known cache keys
+   */
+  getKnownCacheKeys(): string[] {
+    return [...ALL_CACHE_KEYS];
+  }
+
+  /**
+   * Process a cache key to ensure it has proper prefix
+   */
+  private processKey(key: string): string {
+    // If it's a known raw key, use the prefixed version
+    if (RAW_TO_PREFIXED_MAP[key]) {
+      return RAW_TO_PREFIXED_MAP[key];
+    }
+
+    // If it already has our prefix, use it as is
+    if (key.startsWith(CACHE_CONFIG.KEY_PREFIX)) {
+      return key;
+    }
+
+    // Otherwise, add the prefix
+    return createCacheKey(key);
+  }
+}


### PR DESCRIPTION
# Description

Standardizes the caching implementation across the application to fix inconsistencies and improve maintainability. It addresses multiple issues with the existing caching approach:

  1. Removes the redundant double-caching using both interceptors and manual caching
  2. Establishes consistent TTLs through a centralized configuration
  3. Implements proper cache key management with prefixing
  4. Provides backward compatibility for existing cache keys
  5. Enhances the CacheService with better typing and error handling

 These changes ensure cache invalidation works predictably and prevents potential race conditions or stale data issues caused by mismatched TTLs.

## Other changes

  - Added helper functions for cache key creation and management
  - Enhanced cache invalidation to clear both prefixed and legacy keys
  - Improved error handling and logging in cache operations
  - Added type safety to cache get/set operations

## Tested

The changes were tested by:
  1. Manual testing of cache key invalidation through the API
  2. Verifying that cache warming still functions correctly
  3. Confirming proper TTL application for cached data