### PR TITLE
feat: Multicall Service for more efficient balance fetching and avoiding rate limits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,9 @@ RUN pnpm run build
 # Production stage
 FROM node:18-alpine AS production
 
-ENV NODE_ENV=production PORT=8080
+# Default to production, but allow override via --build-arg or at runtime
+ARG NODE_ENV=production
+ENV NODE_ENV=${NODE_ENV} PORT=8080
 
 WORKDIR /app
 

--- a/bin/get-logs.sh
+++ b/bin/get-logs.sh
@@ -9,15 +9,15 @@ region="us-central1"
 
 # Fetch the logs and store in a variable to ensure we have complete JSON
 raw_logs=$(gcloud logging read \
-  "resource.type=cloud_run_revision AND resource.labels.service_name=${service_name} AND severity>=WARNING" \
-  --project=${project_name} \
-  --limit=50 \
-  --format="json") || exit 1
+	"resource.type=cloud_run_revision AND resource.labels.service_name=${service_name} AND severity>=WARNING" \
+	--project="${project_name}" \
+	--limit=50 \
+	--format="json") || exit 1
 
 # Check if the output is valid JSON
-if ! echo "${raw_logs}" | jq empty > /dev/null 2>&1; then
-  echo "Error: Invalid JSON output from gcloud"
-  exit 1
+if ! echo "${raw_logs}" | jq empty >/dev/null 2>&1; then
+	echo "Error: Invalid JSON output from gcloud"
+	exit 1
 fi
 
 # Process and format the logs
@@ -31,4 +31,4 @@ end'
 console_url="https://console.cloud.google.com/run/detail/${region}/${service_name}/logs?project=${project_name}"
 
 # Add clickable link to full logs with proper formatting
-printf "\n\033[34mView full logs:\033[0m \033[34m\033[4m%s\033[0m\n" "$console_url"
+printf "\n\033[34mView full logs:\033[0m \033[34m\033[4m%s\033[0m\n" "${console_url}"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "bignumber.js": "^9.1.2",
     "cache-manager": "5.7.6",
     "ethers": "^6.13.4",
+    "ethers-multicall-provider": "^6.5.0",
     "limiter": "^2.1.0",
     "nestjs-pino": "^4.1.0",
     "pino": "^9.5.0",
@@ -84,5 +85,17 @@
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"
+  },
+  "volta": {
+    "node": "22.14.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@nestjs/core",
+      "@scarf/scarf",
+      "@sentry/cli",
+      "@sentry/profiling-node",
+      "nestjs-pino"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       ethers:
         specifier: ^6.13.4
         version: 6.13.4
+      ethers-multicall-provider:
+        specifier: ^6.5.0
+        version: 6.5.0(ethers@6.13.4)
       limiter:
         specifier: ^2.1.0
         version: 2.1.0
@@ -1563,6 +1566,9 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  dataloader@2.2.3:
+    resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
+
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
@@ -1794,6 +1800,12 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  ethers-multicall-provider@6.5.0:
+    resolution: {integrity: sha512-cEkuuesFkQJiPGs6sFmjnNdMOkP/YW6Jr7uagUEB7Gbiu5EkteNNyigaAZfPNqhmNTOXemWI5Xi5tnt76HmQmw==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      ethers: ^6.0.0
 
   ethers@6.13.4:
     resolution: {integrity: sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==}
@@ -5179,6 +5191,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  dataloader@2.2.3: {}
+
   dateformat@4.6.3: {}
 
   debug@2.6.9:
@@ -5377,6 +5391,11 @@ snapshots:
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
+
+  ethers-multicall-provider@6.5.0(ethers@6.13.4):
+    dependencies:
+      dataloader: 2.2.3
+      ethers: 6.13.4
 
   ethers@6.13.4:
     dependencies:

--- a/src/api/reserve/config/addresses.config.ts
+++ b/src/api/reserve/config/addresses.config.ts
@@ -1,4 +1,4 @@
-import { Chain, AddressCategory, ReserveAddressConfig } from '@types';
+import { AddressCategory, Chain, ReserveAddressConfig } from '@types';
 
 /**
  * The list of addresses that hold reserve assets.
@@ -21,7 +21,7 @@ export const RESERVE_ADDRESS_CONFIGS: ReserveAddressConfig[] = [
     address: '0x87647780180b8f55980c7d3ffefe08a9b29e9ae1',
     chain: Chain.CELO,
     category: AddressCategory.UNIV3_POOL,
-    label: 'Reserve multisig on Celo',
+    label: 'Reserve Multisig on Celo',
     assets: ['CELO', 'WETH', 'USDT'],
     description: 'A reserve owned multisig with positions in Uniswap V3 on Celo',
   },
@@ -29,7 +29,7 @@ export const RESERVE_ADDRESS_CONFIGS: ReserveAddressConfig[] = [
     address: '0x87647780180b8f55980c7d3ffefe08a9b29e9ae1',
     chain: Chain.CELO,
     category: AddressCategory.MENTO_RESERVE,
-    label: 'Reserve multisig on Celo',
+    label: 'Reserve Multisig on Celo',
     assets: ['CELO', 'USDGLO', 'USDC', 'WETH', 'stEUR'],
     description: `A reserve owned multisig holding assets on Celo`,
   },
@@ -37,7 +37,7 @@ export const RESERVE_ADDRESS_CONFIGS: ReserveAddressConfig[] = [
     address: '0x13a9803d547332c81Ebc6060F739821264DBcf1E',
     chain: Chain.CELO,
     category: AddressCategory.MENTO_RESERVE,
-    label: 'Reserve address',
+    label: 'Reserve Address',
     assets: ['CELO'],
     description: 'Holds reserve owned funds on CELO',
   },
@@ -45,7 +45,7 @@ export const RESERVE_ADDRESS_CONFIGS: ReserveAddressConfig[] = [
     address: '0xDA7BFEF937F0944551a24b4C68B054bfA7127570',
     chain: Chain.CELO,
     category: AddressCategory.MENTO_RESERVE,
-    label: 'Operational account',
+    label: 'Operational Account',
     assets: ['CELO', 'USDC', 'USDT', 'axlEUROC', 'axlUSDC'],
     description: 'Holds reserve assets for operational and rebalancing purposes',
   },
@@ -53,7 +53,7 @@ export const RESERVE_ADDRESS_CONFIGS: ReserveAddressConfig[] = [
     address: '0xDA7BFEF937F0944551a24b4C68B054bfA7127570',
     chain: Chain.ETHEREUM,
     category: AddressCategory.MENTO_RESERVE,
-    label: 'Operational account',
+    label: 'Operational Account',
     assets: ['USDC', 'USDT', 'EURC'],
     description: 'Holds reserve assets for operational and rebalancing purposes',
   },

--- a/src/api/reserve/services/balance-fetchers/celo.balance-fetcher.ts
+++ b/src/api/reserve/services/balance-fetchers/celo.balance-fetcher.ts
@@ -1,12 +1,13 @@
-import { withRetry } from '@/utils';
-import { Injectable, Logger } from '@nestjs/common';
-import { AddressCategory, Chain } from '@types';
-import { BalanceFetcherConfig, BaseBalanceFetcher } from '.';
-import { ERC20BalanceFetcher } from './erc20-balance-fetcher';
+import { handleFetchError, withRetry } from '@/utils';
 import { ChainProvidersService } from '@common/services/chain-provider.service';
 import { EthersAdapter, UniV3SupplyCalculator } from '@mento-protocol/mento-sdk';
-import { UNIV3_POSITION_MANAGER_ADDRESS, UNIV3_FACTORY_ADDRESS } from '../../constants';
+import { Injectable, Logger } from '@nestjs/common';
 import * as Sentry from '@sentry/nestjs';
+import { AddressCategory, Chain } from '@types';
+import { BalanceFetcherConfig, BaseBalanceFetcher } from '.';
+import { UNIV3_FACTORY_ADDRESS, UNIV3_POSITION_MANAGER_ADDRESS } from '../../constants';
+import { ERC20BalanceFetcher } from './erc20-balance-fetcher';
+
 @Injectable()
 export class CeloBalanceFetcher extends BaseBalanceFetcher {
   private readonly logger = new Logger(CeloBalanceFetcher.name);
@@ -21,6 +22,13 @@ export class CeloBalanceFetcher extends BaseBalanceFetcher {
     this.erc20Fetcher = new ERC20BalanceFetcher(this.chainProviders.getProvider(Chain.CELO));
   }
 
+  /**
+   * Fetches the balance of a specific token for a given account address and category
+   * @param tokenAddress - The address of the token to fetch the balance of
+   * @param accountAddress - The address of the account to fetch the token balance of
+   * @param category - The category of the address to fetch the balance of
+   * @returns The balance of the token for the given account address and category
+   */
   async fetchBalance(tokenAddress: string | null, accountAddress: string, category: AddressCategory): Promise<string> {
     switch (category) {
       case AddressCategory.MENTO_RESERVE:
@@ -32,13 +40,42 @@ export class CeloBalanceFetcher extends BaseBalanceFetcher {
     }
   }
 
+  /**
+   * Fetches the balance of a Mento reserve for a specific account address
+   *
+   * It uses the ERC20BalanceFetcher to fetch the balance of the token.
+   *
+   * The process involves:
+   * 1. Fetching the balance with retry logic to handle transient failures
+   * 2. Handling errors with appropriate logging and Sentry capture
+   *
+   * @param tokenAddress - The address of the token to check the balance for
+   * @param accountAddress - The address of the account that owns the reserve
+   * @returns A promise resolving to the token balance as a string
+   * @throws Will throw an error if the balance cannot be fetched after retries
+   */
   private async fetchMentoReserveBalance(tokenAddress: string, accountAddress: string): Promise<string> {
     try {
-      const balance = await this.erc20Fetcher.fetchBalance(tokenAddress, accountAddress, Chain.CELO);
-      return balance;
+      const result = await this.erc20Fetcher.fetchBalance(tokenAddress, accountAddress, Chain.CELO);
+      if (!result.success) {
+        throw new Error(`Failed to fetch balance of token ${tokenAddress} for address ${accountAddress}`);
+      }
+
+      return result.balance;
     } catch (error) {
-      const errorMessage = `Failed to fetch balance for token ${tokenAddress} at address ${accountAddress}`;
-      this.logger.error(error, errorMessage);
+      const errorMessage = `Failed to fetch balance of token ${tokenAddress} for address ${accountAddress}`;
+
+      const { isRateLimit, isPaymentRequired, message } = handleFetchError(error, {
+        tokenAddress,
+        accountAddress,
+      });
+
+      if (isRateLimit || isPaymentRequired) {
+        this.logger.warn(message);
+      } else {
+        this.logger.error(error, errorMessage);
+      }
+
       Sentry.captureException(error, {
         level: 'error',
         extra: {
@@ -52,6 +89,24 @@ export class CeloBalanceFetcher extends BaseBalanceFetcher {
     }
   }
 
+  /**
+   * Fetches the token balance from a Uniswap V3 pool
+   *
+   * This method retrieves the token balance held in a Uniswap V3 pool for a specific
+   * account address. It uses the Mento SDK's UniV3SupplyCalculator to determine the
+   * amount of tokens in the pool positions owned by the account.
+   *
+   * The process involves:
+   * 1. Creating an EthersAdapter with the Celo provider
+   * 2. Initializing a UniV3SupplyCalculator with the adapter and pool addresses
+   * 3. Fetching the token amount with retry logic to handle transient failures
+   * 4. Handling errors with appropriate logging and Sentry capture
+   *
+   * @param tokenAddress - The address of the token to check the balance for
+   * @param accountAddress - The address of the account that owns the pool position
+   * @returns A promise resolving to the token balance as a string
+   * @throws Will throw an error if the balance cannot be fetched after retries
+   */
   private async fetchUniv3PoolBalance(tokenAddress: string, accountAddress: string): Promise<string> {
     try {
       const adapter = new EthersAdapter(this.chainProviders.getProvider(Chain.CELO));
@@ -74,7 +129,17 @@ export class CeloBalanceFetcher extends BaseBalanceFetcher {
       );
       return (holdings || '0').toString();
     } catch (error) {
-      this.logger.error(error);
+      const { isRateLimit, isPaymentRequired, message } = handleFetchError(error, {
+        tokenAddress,
+        accountAddress,
+      });
+
+      if (isRateLimit || isPaymentRequired) {
+        this.logger.warn(message);
+      } else {
+        this.logger.error(error);
+      }
+
       Sentry.captureException(error, {
         level: 'error',
         extra: {
@@ -82,6 +147,7 @@ export class CeloBalanceFetcher extends BaseBalanceFetcher {
           chain: Chain.CELO,
           category: AddressCategory.UNIV3_POOL,
           description: error.message,
+          tokenAddress: tokenAddress,
         },
       });
       throw error;

--- a/src/api/reserve/services/balance-fetchers/erc20-balance-fetcher.ts
+++ b/src/api/reserve/services/balance-fetchers/erc20-balance-fetcher.ts
@@ -1,41 +1,128 @@
-import { Contract, Provider } from 'ethers';
-import { ERC20_ABI } from '@mento-protocol/mento-sdk';
-import { Logger } from '@nestjs/common';
-import { retryWithCondition } from '@/utils';
 import { Chain } from '@/types';
+import { handleFetchError, retryWithCondition } from '@/utils';
+import { Logger } from '@nestjs/common';
+import { Contract, Provider } from 'ethers';
+
+interface BalanceResult {
+  balance: string;
+
+  // The success flag is to distinguish between a failed fetch and a legitimately zero balance
+  success: boolean;
+}
 
 export class ERC20BalanceFetcher {
+  private readonly logger = new Logger(ERC20BalanceFetcher.name);
+  private readonly erc20Abi = ['function balanceOf(address) view returns (uint256)'];
+
   constructor(private provider: Provider) {}
 
   /**
-   * Fetch the balance of a token for a given holder address
+   * Fetch the balance of an ERC20 token for a given account address
    * @param tokenAddress - The address of the token (or null for native token)
-   * @param holderAddress - The address of the holder
-   * @returns The balance of the token
+   * @param accountAddress - The address of the holder
+   * @returns Object containing the balance and whether the call was successful
    */
-  async fetchBalance(tokenAddress: string | null, holderAddress: string, chain: Chain): Promise<string> {
-    const balance = await retryWithCondition(
+  async fetchBalance(tokenAddress: string | null, accountAddress: string, chain: Chain): Promise<BalanceResult> {
+    // Handle native token case directly
+    if (!tokenAddress) {
+      const balance = await this.fetchNativeBalance(accountAddress, chain);
+      return { balance, success: true };
+    }
+
+    try {
+      // Create a contract instance with the provider (which is already wrapped with MulticallWrapper)
+      const contract = new Contract(tokenAddress, this.erc20Abi, this.provider);
+
+      // Call balanceOf - this will be automatically batched with other calls
+      const balance = await contract.balanceOf(accountAddress);
+
+      return {
+        balance: balance.toString(),
+        success: true,
+      };
+    } catch (error) {
+      const { isRateLimit, isPaymentRequired, message } = handleFetchError(error, {
+        tokenAddress,
+        accountAddress,
+      });
+
+      if (isRateLimit || isPaymentRequired) {
+        this.logger.warn(message);
+      } else {
+        this.logger.error(
+          `Failed to fetch balance for token=${tokenAddress}, holder=${accountAddress}, chain=${chain}, error=${error.message}`,
+        );
+      }
+
+      return {
+        balance: '0',
+        success: false,
+      };
+    }
+  }
+
+  /**
+   * Fetches the native token balance for a given address
+   *
+   * This method retrieves the native token balance (ETH, CELO, BTC) for the specified
+   * holder address using the chain's provider. It includes retry logic to handle
+   * transient failures and proper error handling for common provider errors.
+   *
+   * @param holderAddress - The address to check the native balance for
+   * @param chain - The chain (determines which native token to fetch)
+   * @returns A promise resolving to the native token balance as a string
+   * @throws Will throw an error if all retry attempts fail
+   */
+  private async fetchNativeBalance(holderAddress: string, chain: Chain): Promise<string> {
+    // Get the appropriate native token symbol based on chain
+    const nativeTokenSymbol = this.getNativeTokenSymbol(chain);
+
+    return retryWithCondition(
       async () => {
-        // Handle native token (ETH) case
-        if (!tokenAddress) {
+        try {
           const balance = await this.provider.getBalance(holderAddress);
           return balance.toString();
-        }
+        } catch (error) {
+          const { isRateLimit, isPaymentRequired, message } = handleFetchError(error, {
+            accountAddress: holderAddress,
+            tokenAddress: nativeTokenSymbol,
+          });
 
-        // Handle ERC20 tokens
-        const contract = new Contract(tokenAddress, ERC20_ABI, this.provider);
-        const balance = await contract.balanceOf(holderAddress);
-        return balance.toString();
+          if (isRateLimit || isPaymentRequired) {
+            this.logger.warn(message);
+          } else {
+            this.logger.error(
+              `Failed to fetch native balance for holder=${holderAddress}, chain=${chain}, error=${error.message}`,
+            );
+          }
+          throw error;
+        }
       },
       (balance) => balance !== undefined && balance !== null,
       {
         maxRetries: 3,
-        logger: new Logger('ERC20BalanceFetcher'),
+        logger: this.logger,
         baseDelay: 1000,
-        warningMessage: `Failed to fetch balance for asset ${tokenAddress} on ${chain.toString()} at ${holderAddress}`,
+        warningMessage: `Failed to fetch ${nativeTokenSymbol} balance for ${holderAddress}`,
       },
     );
+  }
 
-    return balance;
+  /**
+   * Get the native token symbol for a given chain
+   * @param chain - The blockchain chain
+   * @returns The native token symbol (e.g., 'ETH', 'CELO')
+   */
+  private getNativeTokenSymbol(chain: Chain): string {
+    switch (chain) {
+      case Chain.ETHEREUM:
+        return 'ETH';
+      case Chain.CELO:
+        return 'CELO';
+      case Chain.BITCOIN:
+        return 'BTC';
+      default:
+        return 'NATIVE';
+    }
   }
 }

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -1,10 +1,10 @@
 import { Global, Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { MentoService } from './services/mento.service';
-import { ExchangeRatesService } from './services/exchange-rates.service';
-import { PriceFetcherService } from './services/price-fetcher.service';
-import { ChainProvidersService } from './services/chain-provider.service';
 import { CacheService } from './services/cache.service';
+import { ChainProvidersService } from './services/chain-provider.service';
+import { ExchangeRatesService } from './services/exchange-rates.service';
+import { MentoService } from './services/mento.service';
+import { PriceFetcherService } from './services/price-fetcher.service';
 
 @Global()
 @Module({

--- a/src/common/services/chain-provider.service.ts
+++ b/src/common/services/chain-provider.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { JsonRpcProvider, Provider } from 'ethers';
 import { ConfigService } from '@nestjs/config';
 import { Chain } from '@types';
+import { JsonRpcProvider, Provider } from 'ethers';
+import { MulticallWrapper } from 'ethers-multicall-provider';
 
 @Injectable()
 export class ChainProvidersService {
@@ -22,14 +23,19 @@ export class ChainProvidersService {
       throw new Error('ETH_RPC_URL is not set');
     }
 
-    this.providers.set(Chain.CELO, new JsonRpcProvider(celoRpcUrl, 4220, { staticNetwork: true }));
-    this.providers.set(Chain.ETHEREUM, new JsonRpcProvider(ethereumRpcUrl, 1, { staticNetwork: true }));
+    // Create base providers
+    const celoProvider = new JsonRpcProvider(celoRpcUrl, 42220, { staticNetwork: true });
+    const ethereumProvider = new JsonRpcProvider(ethereumRpcUrl, 1, { staticNetwork: true });
+
+    // Wrap with MulticallWrapper
+    this.providers.set(Chain.CELO, MulticallWrapper.wrap(celoProvider));
+    this.providers.set(Chain.ETHEREUM, MulticallWrapper.wrap(ethereumProvider));
   }
 
   /**
    * Get a provider for a given chain
    * @param chain - The chain to get the provider for
-   * @returns The provider for the chain
+   * @returns The provider for the chain (wrapped with MulticallWrapper)
    */
   getProvider(chain: Chain): Provider {
     const provider = this.providers.get(chain);

--- a/src/utils/error.util.ts
+++ b/src/utils/error.util.ts
@@ -1,0 +1,29 @@
+/**
+ * Detects the type of provider error and generates appropriate messages
+ * @param error - The error object from a provider call
+ * @param context - Context information for error messages (e.g., token address)
+ * @returns Object with error type flags and formatted messages
+ */
+export function handleFetchError(
+  error: any,
+  context: {
+    tokenAddress: string;
+    accountAddress: string;
+  },
+) {
+  const { tokenAddress, accountAddress } = context;
+  const isRateLimit = error?.code === 'BAD_DATA' && error?.value?.[0]?.code === -32005;
+  const isPaymentRequired = error?.code === 'SERVER_ERROR' && error?.info?.responseStatus === '402 Payment Required';
+
+  // Generate appropriate messages based on error type and context
+  const rateLimitMessage = `Rate limit exceeded while fetching balance for ${tokenAddress} for ${accountAddress}`;
+  const paymentRequiredMessage = `Payment required error while fetching balance for ${tokenAddress} for ${accountAddress} - daily limit reached`;
+
+  const message = isPaymentRequired ? paymentRequiredMessage : isRateLimit ? rateLimitMessage : null;
+
+  return {
+    isRateLimit,
+    isPaymentRequired,
+    message,
+  };
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
+export * from './error.util';
 export * from './retry.util';

--- a/src/utils/retry.util.ts
+++ b/src/utils/retry.util.ts
@@ -33,9 +33,20 @@ export async function withRetry<T>(
       return await operation();
     } catch (error) {
       attempt++;
-      logger.warn(error, `${errorMessage} after ${attempt} attempts. Retrying...`);
+      // Format rate limit errors more concisely
+      if (error?.code === 'BAD_DATA' && error?.value?.[0]?.code === -32005) {
+        logger.warn(`Rate limit exceeded. Attempt ${attempt}/${maxRetries}. Waiting before retry...`);
+      } else {
+        logger.warn(`${errorMessage} after ${attempt} attempts. Retrying...`);
+      }
+
       if (attempt === maxRetries) {
-        logger.error(error, `${errorMessage} after ${maxRetries} attempts`);
+        // For the final error, log more details but still keep it readable
+        if (error?.code === 'BAD_DATA' && error?.value?.[0]?.code === -32005) {
+          logger.error(`Rate limit exceeded. All ${maxRetries} retry attempts failed.`);
+        } else {
+          logger.error(error, `${errorMessage} after ${maxRetries} attempts`);
+        }
         throw error;
       }
       // Exponential backoff


### PR DESCRIPTION
## Description
My PR adding Celo got accepted so we can now just use [ethers-multicall-provider](https://www.npmjs.com/package/ethers-multicall-provider) to optimize balance fetching operations by batching multiple ERC20 `balanceOf` calls into single RPC requests. This reduces the number of RPC calls made to the RPC providers, helping us stay within rate limits while improving overall performance.

## Future Considerations
- The UniV3Calculator lives in the `mento-sdk` and hence does not use Multicall yet