### PR TITLE
refactor: reduce sentry noise

### DIFF
--- a/src/api/reserve/services/balance-fetchers/ethereum.balance-fetcher.ts
+++ b/src/api/reserve/services/balance-fetchers/ethereum.balance-fetcher.ts
@@ -3,7 +3,6 @@ import { AddressCategory, Chain } from 'src/types';
 import { BalanceFetcherConfig, BaseBalanceFetcher } from '.';
 import { ERC20BalanceFetcher } from './erc20-balance-fetcher';
 import { ChainClientService } from '@/common/services/chain-client.service';
-import * as Sentry from '@sentry/nestjs';
 @Injectable()
 export class EthereumBalanceFetcher extends BaseBalanceFetcher {
   private readonly logger = new Logger(EthereumBalanceFetcher.name);
@@ -28,22 +27,6 @@ export class EthereumBalanceFetcher extends BaseBalanceFetcher {
   }
 
   private async fetchMentoReserveBalance(tokenAddress: string | null, accountAddress: string): Promise<string> {
-    try {
-      const balance = await this.erc20Fetcher.fetchBalance(tokenAddress, accountAddress, Chain.ETHEREUM);
-      return balance;
-    } catch (error) {
-      const errorMessage = `Failed to fetch balance for token ${tokenAddress || 'ETH'} at address ${accountAddress}:`;
-      this.logger.error(error, errorMessage);
-      Sentry.captureException(error, {
-        level: 'error',
-        extra: {
-          address: accountAddress,
-          chain: Chain.ETHEREUM,
-          category: AddressCategory.MENTO_RESERVE,
-          description: errorMessage,
-        },
-      });
-      throw error;
-    }
+    return await this.erc20Fetcher.fetchBalance(tokenAddress, accountAddress, Chain.ETHEREUM);
   }
 }

--- a/src/common/constants/fiat-mappings.constants.ts
+++ b/src/common/constants/fiat-mappings.constants.ts
@@ -14,4 +14,7 @@ export const STABLE_TOKEN_FIAT_MAPPING = {
   cZAR: 'ZAR',
   cAUD: 'AUD',
   cCAD: 'CAD',
+  cJPY: 'JPY',
+  cNGN: 'NGN',
+  cCHF: 'CHF',
 };

--- a/src/common/services/chain-client.service.ts
+++ b/src/common/services/chain-client.service.ts
@@ -26,18 +26,8 @@ export class ChainClientService {
       throw new Error('ETH_RPC_URL is not set');
     }
 
-    // TODO: Investigate the implications of using keepAlive and retryCount on RPC credits
-    // const wsConfig: WebSocketTransportConfig = {
-    //   keepAlive: true,
-    //   retryCount: 5,
-    //   retryDelay: 5000,
-    //   reconnect: {
-    //     attempts: 5,
-    //     delay: 5000,
-    //   },
-    // };
-
     const wsConfig: WebSocketTransportConfig = {
+      timeout: 20000,
       reconnect: {
         attempts: 5,
         delay: 5000,

--- a/src/utils/retry.util.ts
+++ b/src/utils/retry.util.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
 
 interface RetryOptions {
   maxRetries?: number;
@@ -36,6 +37,12 @@ export async function withRetry<T>(
       logger.warn(error, `${errorMessage} after ${attempt} attempts. Retrying...`);
       if (attempt === maxRetries) {
         logger.error(error, `${errorMessage} after ${maxRetries} attempts`);
+        Sentry.captureException(error, {
+          level: 'error',
+          extra: {
+            description: errorMessage,
+          },
+        });
         throw error;
       }
       // Exponential backoff


### PR DESCRIPTION
# Description

This pull request includes several changes to the `balance-fetchers` and related utilities to simplify error handling and improve logging. The most important changes involve removing Sentry error handling from individual balance fetchers and centralizing it in the retry utility.

Error handling simplification:

* [`src/api/reserve/services/balance-fetchers/celo.balance-fetcher.ts`](diffhunk://#diff-30e4807cc7ada6a85acca3fe91038006f6a2095cd336db0ac8c1d6f90ed3362fL38-L58): Removed Sentry error handling and try-catch blocks from `fetchMentoReserveBalance`, `fetchUniv3PoolBalance`, and `fetchAaveBalance` methods. [[1]](diffhunk://#diff-30e4807cc7ada6a85acca3fe91038006f6a2095cd336db0ac8c1d6f90ed3362fL38-L58) [[2]](diffhunk://#diff-30e4807cc7ada6a85acca3fe91038006f6a2095cd336db0ac8c1d6f90ed3362fL67-L122)
* [`src/api/reserve/services/balance-fetchers/ethereum.balance-fetcher.ts`](diffhunk://#diff-03d197d349f4ff18f626dd715a29b2302f1047aa585dc7526332fa60fcf0dd55L31-R30): Removed Sentry error handling and try-catch blocks from `fetchMentoReserveBalance` method.

Centralized error logging:

* [`src/utils/retry.util.ts`](diffhunk://#diff-2d116380746b4e743f15af13501f42f0c00a75a14bef3b83b8527270250a4094R40-R45): Added Sentry error handling to the `withRetry` function to capture exceptions at the retry utility level.

Miscellaneous updates:

* [`src/common/constants/fiat-mappings.constants.ts`](diffhunk://#diff-767d017877117ac26925407459645174e91b37ddb8d3b4e11a832051441e8e77R17-R19): Added new fiat mappings for `cJPY`, `cNGN`, and `cCHF`.
* [`src/common/services/chain-client.service.ts`](diffhunk://#diff-cab48707ab0ed2370ad6332488b3ebe8147afeed0bf1e3925c118eee60529d28L29-R30): Updated WebSocket configuration to include a timeout setting (double default value).

🤖 Summary generated by co-pilot