### PR TITLE
feat: add sUSDS to reserve holdings tracking

### DIFF
--- a/src/api/reserve/config/addresses.config.ts
+++ b/src/api/reserve/config/addresses.config.ts
@@ -38,7 +38,7 @@ export const RESERVE_ADDRESS_CONFIGS: ReserveAddressConfig[] = [
     chain: Chain.ETHEREUM,
     category: AddressCategory.MENTO_RESERVE,
     label: 'Mento Reserve Custody Multisig',
-    assets: ['ETH', 'WBTC', 'stETH', 'EURC', 'sDAI', 'USDC'],
+    assets: ['ETH', 'WBTC', 'stETH', 'EURC', 'USDC', 'sUSDS'],
     description: 'Main Mento reserve holding collateral assets on Ethereum',
   },
   {

--- a/src/api/reserve/config/assets.config.ts
+++ b/src/api/reserve/config/assets.config.ts
@@ -102,6 +102,19 @@ export const ASSETS_CONFIGS: Record<Chain, Partial<Record<AssetSymbol, AssetConf
       decimals: 18,
       address: '0x83F20F44975D03b1b09e64809B757c47f942BEeA',
     },
+    sUSDS: {
+      symbol: 'sUSDS',
+      name: 'Savings USDS',
+      decimals: 18,
+      address: '0xa3931d71877c0e7a3148cb7eb4463524fec27fbd',
+      rateSymbol: 'USDS', // TODO: change to sUSDS once added to coinmarketcap
+    },
+    USDS: {
+      symbol: 'USDS',
+      name: 'USDS Stablecoin',
+      decimals: 18,
+      address: '0xdc035d45d973e3ec169d2276ddab16f1e407384f',
+    },
     USDC: {
       symbol: 'USDC',
       name: 'USD Coin',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -104,6 +104,8 @@ export const ASSET_SYMBOLS = {
   USDGLO: 'USDGLO',
   WETH: 'WETH',
   sDAI: 'sDAI',
+  sUSDS: 'sUSDS',
+  USDS: 'USDS',
   stEUR: 'stEUR',
   axlEUROC: 'axlEUROC',
 } as const;


### PR DESCRIPTION
# Description

This Pr adds sUSDS to the list of reserve assets we track. Since CoinMarketCap doesn't provide the sUSDS rate via their API we will use the USDS rate for now. This means we won't be tracking the yield generated on our USDS holdings, but just the USDS USD value for now. I will email them to get an eta on when they will integrate sUSDS. 

## Other changes



## Tested

ran locally and verified balance and USD conversion

## Related issues

