### PR TITLE
Convert RPC URLs to secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ COINMARKETCAP_API_KEY=
 EXCHANGE_RATES_API_KEY=
 
 # RPC URLs
+# For local development, use these public endpoints
+# For preview/production, these are managed as secrets in Google Secret Manager
 CELO_RPC_URL=wss://forno.celo.org/ws
 ETH_RPC_URL=wss://mainnet.gateway.tenderly.co
 

--- a/cloudbuild-cleanup.yaml
+++ b/cloudbuild-cleanup.yaml
@@ -92,8 +92,9 @@ steps:
         echo "IMPORTANT: Only cleaning preview images, preserving production 'latest' tag"
         
         # List preview images for this branch (keep only the last 3)
+        # Preview images are stored in the analytics-api-preview repository
         IMAGES=$$(gcloud artifacts docker images list \
-          ${_AR_HOSTNAME}/${_AR_PROJECT_ID}/${_AR_REPOSITORY}/mento-analytics-api \
+          ${_AR_HOSTNAME}/${_AR_PROJECT_ID}/${_AR_REPOSITORY}/${_SERVICE_NAME_PREFIX} \
           --include-tags \
           --filter="tags:${_BRANCH_TAG}-*" \
           --format="get(digest)" \
@@ -104,7 +105,7 @@ steps:
           for IMAGE in $$IMAGES; do
             echo "Deleting preview image: $$IMAGE"
             gcloud artifacts docker images delete \
-              "${_AR_HOSTNAME}/${_AR_PROJECT_ID}/${_AR_REPOSITORY}/mento-analytics-api@$$IMAGE" \
+              "${_AR_HOSTNAME}/${_AR_PROJECT_ID}/${_AR_REPOSITORY}/${_SERVICE_NAME_PREFIX}-api-preview@$$IMAGE" \
               --quiet || true
           done
           echo "Preview image cleanup completed for branch: ${_BRANCH_NAME}"
@@ -121,6 +122,19 @@ steps:
           echo "✅ Production 'latest' tag is safe and intact"
         else
           echo "❌ WARNING: Production 'latest' tag is missing!"
+          exit 1
+        fi
+        
+        # Verify preview 'latest' tag is still intact
+        echo "Verifying preview 'latest' tag is still intact..."
+        if gcloud artifacts docker images list \
+          ${_AR_HOSTNAME}/${_AR_PROJECT_ID}/${_AR_REPOSITORY}/${_SERVICE_NAME_PREFIX} \
+          --include-tags \
+          --filter="tags:latest" >/dev/null 2>&1; then
+          echo "✅ Preview 'latest' tag is safe and intact"
+        else
+          echo "❌ WARNING: Preview 'latest' tag is missing!"
+          exit 1
         fi
 
 # Tags for this build

--- a/cloudbuild-cleanup.yaml
+++ b/cloudbuild-cleanup.yaml
@@ -83,26 +83,44 @@ steps:
     args:
       - '-c'
       - |
-        # List and delete old images for this branch (keep only the last 3)
-        # Images are tagged with pattern: ${_BRANCH_TAG}-${_SHORT_SHA}
-        # Use Artifact Registry commands instead of Container Registry
+        # CRITICAL: Only clean up preview images, never touch production images or 'latest' tag
+        # All images (production and preview) are stored in the same repository: mento-analytics-api
+        # Preview images are tagged with pattern: ${_BRANCH_TAG}-${_SHORT_SHA}
+        # Production images use commit SHA tags and the 'latest' tag
+        
+        echo "Cleaning up old preview images for branch: ${_BRANCH_NAME} (tag prefix: ${_BRANCH_TAG})"
+        echo "IMPORTANT: Only cleaning preview images, preserving production 'latest' tag"
+        
+        # List preview images for this branch (keep only the last 3)
         IMAGES=$$(gcloud artifacts docker images list \
-          ${_AR_HOSTNAME}/${_AR_PROJECT_ID}/${_AR_REPOSITORY}/${_SERVICE_NAME_PREFIX} \
+          ${_AR_HOSTNAME}/${_AR_PROJECT_ID}/${_AR_REPOSITORY}/mento-analytics-api \
           --include-tags \
           --filter="tags:${_BRANCH_TAG}-*" \
           --format="get(digest)" \
           --sort-by="~timestamp" | tail -n +4)
         
         if [ ! -z "$$IMAGES" ]; then
-          echo "Cleaning up old container images for branch: ${_BRANCH_NAME} (tag prefix: ${_BRANCH_TAG})"
+          echo "Found old preview images to clean up for branch: ${_BRANCH_NAME}"
           for IMAGE in $$IMAGES; do
-            echo "Deleting image: $$IMAGE"
+            echo "Deleting preview image: $$IMAGE"
             gcloud artifacts docker images delete \
-              "${_AR_HOSTNAME}/${_AR_PROJECT_ID}/${_AR_REPOSITORY}/${_SERVICE_NAME_PREFIX}@$$IMAGE" \
+              "${_AR_HOSTNAME}/${_AR_PROJECT_ID}/${_AR_REPOSITORY}/mento-analytics-api@$$IMAGE" \
               --quiet || true
           done
+          echo "Preview image cleanup completed for branch: ${_BRANCH_NAME}"
         else
-          echo "No old images to clean up for branch: ${_BRANCH_NAME} (tag prefix: ${_BRANCH_TAG})"
+          echo "No old preview images to clean up for branch: ${_BRANCH_NAME} (tag prefix: ${_BRANCH_TAG})"
+        fi
+        
+        # Verify we haven't touched production images
+        echo "Verifying production 'latest' tag is still intact..."
+        if gcloud artifacts docker images list \
+          ${_AR_HOSTNAME}/${_AR_PROJECT_ID}/${_AR_REPOSITORY}/mento-analytics-api \
+          --include-tags \
+          --filter="tags:latest" >/dev/null 2>&1; then
+          echo "✅ Production 'latest' tag is safe and intact"
+        else
+          echo "❌ WARNING: Production 'latest' tag is missing!"
         fi
 
 # Tags for this build

--- a/cloudbuild-preview.yaml
+++ b/cloudbuild-preview.yaml
@@ -86,7 +86,7 @@ steps:
           --allow-unauthenticated \
           --timeout=300 \
           --set-env-vars="$$ENV_VARS" \
-          --set-secrets="EXCHANGE_RATES_API_KEY=exchange-rates-api-key-preview:latest,COINMARKETCAP_API_KEY=coinmarketcap-api-key-preview:latest"
+          --set-secrets="EXCHANGE_RATES_API_KEY=exchange-rates-api-key-preview:latest,COINMARKETCAP_API_KEY=coinmarketcap-api-key-preview:latest,CELO_RPC_URL=celo-rpc-url-preview:latest,ETH_RPC_URL=eth-rpc-url-preview:latest"
 
   # Step 3: Get the service URL and save it
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -47,7 +47,7 @@ steps:
           --region=${_DEPLOY_REGION} \
           --quiet \
           --set-env-vars="$$ENV_VARS" \
-          --set-secrets="EXCHANGE_RATES_API_KEY=exchange-rates-api-key-prod:latest,COINMARKETCAP_API_KEY=coinmarketcap-api-key-prod:latest"
+          --set-secrets="EXCHANGE_RATES_API_KEY=exchange-rates-api-key-prod:latest,COINMARKETCAP_API_KEY=coinmarketcap-api-key-prod:latest,CELO_RPC_URL=celo-rpc-url-prod:latest,ETH_RPC_URL=eth-rpc-url-prod:latest"
 
 # Tags for this build
 tags:

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -25,6 +25,11 @@ Default values are defined in `.env.example`
 - `EXCHANGE_RATES_API_KEY`: Exchange rates API authentication
 - `COINMARKETCAP_API_KEY`: CoinMarketCap API authentication
 
+### RPC URLs (Sensitive, stored in Secret Manager)
+
+- `CELO_RPC_URL`: Celo network RPC endpoint with API key
+- `ETH_RPC_URL`: Ethereum network RPC endpoint with API key
+
 ### Runtime Configuration
 
 - `NODE_ENV`: `production` | `development`
@@ -40,10 +45,14 @@ Default values are defined in `.env.example`
 # Production secrets
 coinmarketcap-api-key-prod
 exchange-rates-api-key-prod
+celo-rpc-url-prod
+eth-rpc-url-prod
 
 # Preview secrets (shared by all preview deployments)
 coinmarketcap-api-key-preview
 exchange-rates-api-key-preview
+celo-rpc-url-preview
+eth-rpc-url-preview
 ```
 
 ### 2. Grant Minimal Access
@@ -73,11 +82,15 @@ Production secrets should be set up by your infrastructure team with appropriate
 
 ### Preview Deployments
 
-Run once to set up shared preview secrets:
+Run the unified setup script to configure all secrets:
 
 ```bash
-./scripts/setup-preview-secrets.sh
+./scripts/setup-secrets.sh
 ```
+
+This script will guide you through setting up both API keys and RPC URLs for your chosen environments.
+
+For manual setup of individual secrets, use the gcloud commands shown in the script output.
 
 ### Local Development
 

--- a/docs/preview-deployments.md
+++ b/docs/preview-deployments.md
@@ -126,13 +126,11 @@ Preview deployments use a **shared secrets approach** following Google Cloud bes
 Before preview deployments can work, run the setup script **once**:
 
 ```bash
-# Run this once to set up preview secrets
-./scripts/setup-preview-secrets.sh
-
-# Add your test/sandbox API keys
-echo -n 'YOUR_SANDBOX_COINMARKETCAP_KEY' | gcloud secrets versions add coinmarketcap-api-key-preview --data-file=-
-echo -n 'YOUR_TEST_EXCHANGE_RATES_KEY' | gcloud secrets versions add exchange-rates-api-key-preview --data-file=-
+# Run this once to set up all secrets (API keys and RPC URLs)
+./scripts/setup-secrets.sh
 ```
+
+This unified script will guide you through setting up both API keys and RPC URLs for your chosen environments.
 
 ## Management Scripts
 

--- a/scripts/env-config.sh
+++ b/scripts/env-config.sh
@@ -48,8 +48,8 @@ build_env_vars_string() {
     
     # Add all environment variables from .env file that are currently exported
     # This dynamically includes all env vars without hardcoding them
-    # Exclude API keys that are managed as Cloud Run secrets and Cloud Run reserved variables
-    local env_from_file=$(env | grep -E '^[A-Z_][A-Z0-9_]*=' | grep -vE '^(RELEASE_VERSION|ENVIRONMENT|SENTRY_ENVIRONMENT|PREVIEW_BRANCH|NODE_ENV|PORT|PATH|HOME|USER|PWD|SHELL|TERM|LANG|LC_|GOOGLE_|GCLOUD_|BUILDER_|RESULTS|SHLVL|HOSTNAME|CLOUD_SDK_|OLDPWD|_|.*_API_KEY)' | sed 's/=/=/g' | tr '\n' ',' | sed 's/,$//')
+    # Exclude API keys and RPC URLs that are managed as Cloud Run secrets and Cloud Run reserved variables
+    local env_from_file=$(env | grep -E '^[A-Z_][A-Z0-9_]*=' | grep -vE '^(RELEASE_VERSION|ENVIRONMENT|SENTRY_ENVIRONMENT|PREVIEW_BRANCH|NODE_ENV|PORT|PATH|HOME|USER|PWD|SHELL|TERM|LANG|LC_|GOOGLE_|GCLOUD_|BUILDER_|RESULTS|SHLVL|HOSTNAME|CLOUD_SDK_|OLDPWD|_|.*_API_KEY|CELO_RPC_URL|ETH_RPC_URL)' | sed 's/=/=/g' | tr '\n' ',' | sed 's/,$//')
     
     if [ -n "$env_from_file" ]; then
         env_vars="${env_vars},${env_from_file}"

--- a/scripts/setup-secrets.sh
+++ b/scripts/setup-secrets.sh
@@ -1,0 +1,362 @@
+#!/bin/bash
+
+# Unified setup script for all Mento Analytics API secrets
+# This script creates and manages all secrets needed for preview and production deployments
+
+set -euo pipefail
+
+# Source shared utilities
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/shared-utils.sh"
+
+create_secret_if_not_exists() {
+    local secret_name="$1"
+    local description="$2"
+    local labels="$3"
+    
+    echo -n "Checking if secret '$secret_name' exists... "
+    
+    if gcloud secrets describe "$secret_name" --project="$PROJECT_ID" >/dev/null 2>&1; then
+        print_warning "already exists"
+        return 0
+    else
+        echo "not found, creating..."
+        
+        # Create the secret
+        gcloud secrets create "$secret_name" \
+            --replication-policy="automatic" \
+            --labels="$labels" \
+            --project="$PROJECT_ID"
+        
+        print_success "Secret created: $secret_name"
+        return 1
+    fi
+}
+
+check_secret_has_value() {
+    local secret_name="$1"
+    
+    echo -n "Checking if secret '$secret_name' has a value... "
+    
+    local version_count=$(gcloud secrets versions list "$secret_name" --project="$PROJECT_ID" --format="value(name)" | wc -l)
+    
+    if [ "$version_count" -gt 0 ]; then
+        print_success "has value"
+        return 0
+    else
+        print_warning "no value set"
+        return 1
+    fi
+}
+
+add_secret_value() {
+    local secret_name="$1"
+    local value="$2"
+    local value_type="$3"  # "real" or "placeholder"
+    
+    echo -n "Adding $value_type value to '$secret_name'... "
+    
+    if echo -n "$value" | gcloud secrets versions add "$secret_name" --data-file=- --project="$PROJECT_ID" >/dev/null 2>&1; then
+        print_success "$value_type added"
+    else
+        print_error "failed to add $value_type"
+        return 1
+    fi
+}
+
+prompt_for_api_key() {
+    local service_name="$1"
+    local secret_name="$2"
+    local url="$3"
+    
+    echo ""
+    echo -e "${BLUE}$service_name API Key${NC}"
+    echo "Get your API key from: $url"
+    echo -n "Enter your API key (or press Enter to skip): "
+    
+    # Read without echoing to terminal for security
+    read -s api_key
+    echo  # Add newline since read -s doesn't
+    
+    if [ -n "$api_key" ]; then
+        add_secret_value "$secret_name" "$api_key" "real API key"
+        return 0
+    else
+        echo "Skipping real API key, will use placeholder..."
+        add_secret_value "$secret_name" "preview-placeholder-$(echo $secret_name | cut -d'-' -f1)" "placeholder"
+        return 1
+    fi
+}
+
+prompt_for_rpc_url() {
+    local network_name="$1"
+    local secret_name="$2"
+    local example_url="$3"
+    
+    echo ""
+    echo -e "${BLUE}$network_name RPC URL${NC}"
+    echo "Example: $example_url"
+    echo -n "Enter your RPC URL with API key (or press Enter to skip): "
+    
+    # Read without echoing to terminal for security
+    read -s rpc_url
+    echo  # Add newline since read -s doesn't
+    
+    if [ -n "$rpc_url" ]; then
+        add_secret_value "$secret_name" "$rpc_url" "real RPC URL"
+        return 0
+    else
+        echo "Skipping real RPC URL, will use placeholder..."
+        add_secret_value "$secret_name" "wss://placeholder-$network_name-rpc-url" "placeholder"
+        return 1
+    fi
+}
+
+grant_access_to_default_sa() {
+    local secret_name="$1"
+    
+    # Get the default compute service account
+    PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format="value(projectNumber)")
+    COMPUTE_SA="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+    
+    echo -n "Granting access to default compute service account... "
+    
+    if gcloud secrets add-iam-policy-binding "$secret_name" \
+        --member="serviceAccount:$COMPUTE_SA" \
+        --role="roles/secretmanager.secretAccessor" \
+        --project="$PROJECT_ID" >/dev/null 2>&1; then
+        print_success "granted"
+    else
+        print_warning "may already have access"
+    fi
+}
+
+setup_api_keys() {
+    local environment="$1"
+    
+    print_section "Setting up API Keys for $environment"
+    
+    # Create API key secrets
+    CREATED_CMC=false
+    CREATED_ER=false
+    
+    if create_secret_if_not_exists "coinmarketcap-api-key-$environment" "CoinMarketCap API key for $environment deployments" "purpose=api-keys,environment=$environment"; then
+        CREATED_CMC=true
+    fi
+    
+    if create_secret_if_not_exists "exchange-rates-api-key-$environment" "Exchange Rates API key for $environment deployments" "purpose=api-keys,environment=$environment"; then
+        CREATED_ER=true
+    fi
+    
+    # Grant access
+    grant_access_to_default_sa "coinmarketcap-api-key-$environment"
+    grant_access_to_default_sa "exchange-rates-api-key-$environment"
+    
+    # Check if secrets need values
+    NEEDS_CMC_VALUE=false
+    NEEDS_ER_VALUE=false
+    
+    if ! check_secret_has_value "coinmarketcap-api-key-$environment"; then
+        NEEDS_CMC_VALUE=true
+    fi
+    
+    if ! check_secret_has_value "exchange-rates-api-key-$environment"; then
+        NEEDS_ER_VALUE=true
+    fi
+    
+    # If secrets already have values, ask if user wants to update them
+    if [ "$NEEDS_CMC_VALUE" = false ] && [ "$NEEDS_ER_VALUE" = false ]; then
+        echo ""
+        echo "Both API key secrets already have values."
+        read -p "Do you want to update them with new API keys? (y/N) " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            NEEDS_CMC_VALUE=true
+            NEEDS_ER_VALUE=true
+        fi
+    fi
+    
+    # Prompt for API keys if needed
+    if [ "$NEEDS_CMC_VALUE" = true ]; then
+        prompt_for_api_key "CoinMarketCap" "coinmarketcap-api-key-$environment" "https://coinmarketcap.com/api/"
+    fi
+    
+    if [ "$NEEDS_ER_VALUE" = true ]; then
+        prompt_for_api_key "Exchange Rates API" "exchange-rates-api-key-$environment" "https://exchangeratesapi.io/"
+    fi
+}
+
+setup_rpc_urls() {
+    local environment="$1"
+    
+    print_section "Setting up RPC URLs for $environment"
+    
+    # Create RPC URL secrets
+    CREATED_CELO=false
+    CREATED_ETH=false
+    
+    if create_secret_if_not_exists "celo-rpc-url-$environment" "Celo RPC URL for $environment deployments" "purpose=rpc-urls,environment=$environment"; then
+        CREATED_CELO=true
+    fi
+    
+    if create_secret_if_not_exists "eth-rpc-url-$environment" "Ethereum RPC URL for $environment deployments" "purpose=rpc-urls,environment=$environment"; then
+        CREATED_ETH=true
+    fi
+    
+    # Grant access
+    grant_access_to_default_sa "celo-rpc-url-$environment"
+    grant_access_to_default_sa "eth-rpc-url-$environment"
+    
+    # Check if secrets need values
+    NEEDS_CELO_VALUE=false
+    NEEDS_ETH_VALUE=false
+    
+    if ! check_secret_has_value "celo-rpc-url-$environment"; then
+        NEEDS_CELO_VALUE=true
+    fi
+    
+    if ! check_secret_has_value "eth-rpc-url-$environment"; then
+        NEEDS_ETH_VALUE=true
+    fi
+    
+    # If secrets already have values, ask if user wants to update them
+    if [ "$NEEDS_CELO_VALUE" = false ] && [ "$NEEDS_ETH_VALUE" = false ]; then
+        echo ""
+        echo "Both RPC URL secrets already have values."
+        read -p "Do you want to update them with new RPC URLs? (y/N) " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            NEEDS_CELO_VALUE=true
+            NEEDS_ETH_VALUE=true
+        fi
+    fi
+    
+    # Prompt for RPC URLs if needed
+    if [ "$NEEDS_CELO_VALUE" = true ]; then
+        prompt_for_rpc_url "Celo" "celo-rpc-url-$environment" "wss://celo-mainnet.infura.io/ws/v3/YOUR_API_KEY"
+    fi
+    
+    if [ "$NEEDS_ETH_VALUE" = true ]; then
+        prompt_for_rpc_url "Ethereum" "eth-rpc-url-$environment" "wss://mainnet.infura.io/ws/v3/YOUR_API_KEY"
+    fi
+}
+
+show_manual_commands() {
+    local environment="$1"
+    
+    echo ""
+    echo "To manually update secrets later:"
+    echo ""
+    echo -e "${YELLOW}# API Keys${NC}"
+    echo -e "${YELLOW}echo -n 'NEW_KEY' | gcloud secrets versions add coinmarketcap-api-key-$environment --data-file=- --project=$PROJECT_ID${NC}"
+    echo -e "${YELLOW}echo -n 'NEW_KEY' | gcloud secrets versions add exchange-rates-api-key-$environment --data-file=- --project=$PROJECT_ID${NC}"
+    echo ""
+    echo -e "${YELLOW}# RPC URLs${NC}"
+    echo -e "${YELLOW}echo -n 'wss://your-celo-rpc-url' | gcloud secrets versions add celo-rpc-url-$environment --data-file=- --project=$PROJECT_ID${NC}"
+    echo -e "${YELLOW}echo -n 'wss://your-eth-rpc-url' | gcloud secrets versions add eth-rpc-url-$environment --data-file=- --project=$PROJECT_ID${NC}"
+}
+
+main() {
+    print_section "Mento Analytics API Secrets Setup"
+    
+    echo "This script creates and manages all secrets needed for deployments."
+    echo ""
+    echo "You'll need:"
+    echo "- API keys for CoinMarketCap and Exchange Rates API"
+    echo "- RPC URLs with API keys for Celo and Ethereum networks"
+    echo ""
+    echo "Project: $PROJECT_ID"
+    echo ""
+    
+    # Check if we're authenticated
+    if ! gcloud auth list --filter=status:ACTIVE --format="value(account)" | grep -q .; then
+        print_error "No active gcloud authentication found. Please run 'gcloud auth login' first."
+        exit 1
+    fi
+    
+    # Ask which environments to set up
+    echo "Which environments would you like to set up?"
+    echo "1) Preview only"
+    echo "2) Production only"
+    echo "3) Both preview and production"
+    echo ""
+    read -p "Enter your choice (1-3): " -n 1 -r
+    echo
+    
+    case $REPLY in
+        1)
+            ENVIRONMENTS=("preview")
+            ;;
+        2)
+            ENVIRONMENTS=("prod")
+            ;;
+        3)
+            ENVIRONMENTS=("preview" "prod")
+            ;;
+        *)
+            print_error "Invalid choice. Exiting."
+            exit 1
+            ;;
+    esac
+    
+    # Ask which types of secrets to set up
+    echo ""
+    echo "Which types of secrets would you like to set up?"
+    echo "1) API Keys only"
+    echo "2) RPC URLs only"
+    echo "3) Both API Keys and RPC URLs"
+    echo ""
+    read -p "Enter your choice (1-3): " -n 1 -r
+    echo
+    
+    case $REPLY in
+        1)
+            SETUP_API_KEYS=true
+            SETUP_RPC_URLS=false
+            ;;
+        2)
+            SETUP_API_KEYS=false
+            SETUP_RPC_URLS=true
+            ;;
+        3)
+            SETUP_API_KEYS=true
+            SETUP_RPC_URLS=true
+            ;;
+        *)
+            print_error "Invalid choice. Exiting."
+            exit 1
+            ;;
+    esac
+    
+    # Set up secrets for each environment
+    for env in "${ENVIRONMENTS[@]}"; do
+        print_section "Setting up $env environment"
+        
+        if [ "$SETUP_API_KEYS" = true ]; then
+            setup_api_keys "$env"
+        fi
+        
+        if [ "$SETUP_RPC_URLS" = true ]; then
+            setup_rpc_urls "$env"
+        fi
+        
+        show_manual_commands "$env"
+    done
+    
+    print_section "Setup Complete"
+    
+    echo "✅ All requested secrets have been set up!"
+    echo ""
+    echo "Important notes:"
+    echo "- Preview secrets are shared by ALL preview deployments"
+    echo "- Production secrets are used only for production deployments"
+    echo "- Placeholder values allow deployments to succeed (APIs will return errors)"
+    echo "- Use test/sandbox API keys for real functionality testing"
+    echo "- RPC URLs should include your API keys for better rate limits"
+    echo ""
+    
+    print_success "Setup complete! Deployments can now use these secrets."
+}
+
+# Run main function
+main "$@"

--- a/scripts/shared-utils.sh
+++ b/scripts/shared-utils.sh
@@ -94,3 +94,9 @@ print_warning() {
 print_error() {
     echo -e "${RED}$1${NC}"
 }
+
+print_section() {
+    echo ""
+    echo -e "${BLUE}==== $1 ====${NC}"
+    echo ""
+}


### PR DESCRIPTION
Since switching to public RPC URLs we started seeing some RPC errors again here and there: https://mento-labs.sentry.io/issues/6882051620/?alert_rule_id=15926786&alert_type=issue&notification_uuid=e5619801-8258-40ff-ab45-229565d841de&project=4508518701268992&referrer=discord

This PR is moving the RPC URLs from simple env vars to secrets so we can use our private RPC URLs with API Keys again without leaking them on Github
