### PR TITLE
fix: increase in-memory cache max to prevent LRU eviction

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -23,6 +23,7 @@ import { getLocalPinoConfig, getProductionPinoConfig } from './config/logger.con
     CacheModule.register({
       isGlobal: true,
       ttl: CACHE_CONFIG.TTL.DEFAULT,
+      max: 5000,
     }),
     // Rate limiting: 3-tier (10 req/s, 50 req/10s, 100 req/min per IP)
     ThrottlerModule.forRoot([


### PR DESCRIPTION
## Summary
Root cause of all v2 endpoints being slow (~5-11s every request): the in-memory cache store defaults to **500 entries max**. The primitive cache writes hundreds of balance entries (tokens × addresses × chains), evicting composed endpoint entries via LRU. Bumped to 5000.

## Evidence
```
node -e "const {caching}=require('cache-manager'); (async()=>{const c=await caching('memory',{ttl:3600000}); for(let i=0;i<1000;i++) await c.set('k'+i,{d:'x'.repeat(1000)},3600000); console.log('key-0:',await c.get('k0')!==undefined,'size:',c.store.size)})()"
// key-0: false  size: 500
```

## Test plan
- [ ] Deploy and verify all v2 endpoints respond in <300ms consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)