### PR TITLE
fix: set cache TTLs to 10 minutes

### DIFF
--- a/src/api/v2/services/primitive-cache.service.ts
+++ b/src/api/v2/services/primitive-cache.service.ts
@@ -10,8 +10,8 @@ import { Chain } from '@types';
  * - STABLECOIN_LIST: Essentially static; only changes on protocol upgrades.
  */
 export const PRIMITIVE_TTL = {
-  BALANCE: 30 * 60 * 1000, // 30 minutes
-  POOL_RESERVES: 30 * 60 * 1000, // 30 minutes
+  BALANCE: 10 * 60 * 1000, // 10 minutes
+  POOL_RESERVES: 10 * 60 * 1000, // 10 minutes
   STRUCTURAL: 30 * 60 * 1000, // 30 minutes
   STABLECOIN_LIST: 60 * 60 * 1000, // 1 hour
   READER_SNAPSHOT: 24 * 60 * 60 * 1000, // 24 hours — long-lived fallback

--- a/src/api/v2/services/v2-cache-warmer.service.ts
+++ b/src/api/v2/services/v2-cache-warmer.service.ts
@@ -25,8 +25,8 @@ import { PrimitiveCacheService } from './primitive-cache.service';
  * chain's block time.  Only chains with an RPC block watcher are listed.
  */
 const TIER1_BLOCK_THRESHOLDS: Partial<Record<Chain, number>> = {
-  [Chain.CELO]: (30 * 60) / 1, // ~1800 Celo blocks (1 s block time)
-  [Chain.ETHEREUM]: (30 * 60) / 12, // ~150 Ethereum blocks (12 s block time)
+  [Chain.CELO]: (10 * 60) / 1, // ~600 Celo blocks (1 s block time)
+  [Chain.ETHEREUM]: (10 * 60) / 12, // ~50 Ethereum blocks (12 s block time)
 };
 
 /** Tier 2 interval in milliseconds (~30 min). */
@@ -50,7 +50,7 @@ export interface CacheEntry<T> {
  * Default staleness window: data older than this triggers a background
  * refresh even though it is still returned to the caller immediately.
  */
-const STALE_AFTER_MS = 30 * 60 * 1000; // 30 minutes
+const STALE_AFTER_MS = 10 * 60 * 1000; // 10 minutes
 
 // ---------------------------------------------------------------------------
 // Service


### PR DESCRIPTION
## Summary
Dial back cache TTLs from 30min to 10min for fresher data. Safe now that the LRU max is 5000 (PR #96).

- Primitive balance/pool reserves: 10 min
- Tier 1 block thresholds: ~10 min
- Stale-while-revalidate: 10 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)