### PR TITLE
fix: allow Vercel preview deployments through CORS

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,11 @@ async function bootstrap() {
     'https://mento-analytics-api-12390052758.us-central1.run.app', // Allow requests from the swagger UI under /docs
   ];
 
+  // Dynamic patterns for preview/staging deployments
+  const allowedOriginPatterns = [
+    /^https:\/\/.*\.vercel\.app$/, // Vercel preview deployments
+  ];
+
   // Add localhost for development if NODE_ENV is development
   if (process.env.NODE_ENV === 'development') {
     allowedOrigins.push(`http://localhost:${process.env.PORT || 8080}`);
@@ -37,7 +42,10 @@ async function bootstrap() {
         return callback(null, true);
       }
 
-      if (allowedOrigins.includes(origin)) {
+      if (
+        allowedOrigins.includes(origin) ||
+        allowedOriginPatterns.some((pattern) => pattern.test(origin))
+      ) {
         callback(null, true);
       } else {
         callback(new Error(`Origin ${origin} not allowed by CORS policy`), false);

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ async function bootstrap() {
 
   // Dynamic patterns for preview/staging deployments
   const allowedOriginPatterns = [
-    /^https:\/\/.*\.vercel\.app$/, // Vercel preview deployments
+    /^https:\/\/.*-mentolabs\.vercel\.app$/, // Vercel preview deployments (MentoLabs org)
   ];
 
   // Add localhost for development if NODE_ENV is development

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,10 +42,7 @@ async function bootstrap() {
         return callback(null, true);
       }
 
-      if (
-        allowedOrigins.includes(origin) ||
-        allowedOriginPatterns.some((pattern) => pattern.test(origin))
-      ) {
+      if (allowedOrigins.includes(origin) || allowedOriginPatterns.some((pattern) => pattern.test(origin))) {
         callback(null, true);
       } else {
         callback(new Error(`Origin ${origin} not allowed by CORS policy`), false);


### PR DESCRIPTION
## Summary
- Adds regex-based origin matching (`/^https:\/\/.*\.vercel\.app$/`) alongside the existing static allowlist in `src/main.ts`
- Fixes CORS errors on Vercel preview deployments like `reservemento-<uuid>.MentoLabs.vercel.app`
- No change to existing static origins — they continue to work as before

## Context
The CORS config has always used exact string matching against a hardcoded list. Vercel preview URLs are dynamically generated per deploy, so they never matched. There was never a wildcard/regex pattern — this adds the first one.

Sentry issue: https://mento-labs.sentry.io/issues/6762463110/

## Test plan
- [ ] Deploy to preview and verify a Vercel preview frontend can call the API without CORS errors
- [ ] Verify production origins (mento.org, reserve.mento.org, etc.) still work
- [ ] Verify requests with no origin (SSR, Postman) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)