### PR TITLE
feat: add AUSD to Ethereum assets config

### DIFF
--- a/src/api/reserve/config/assets.config.ts
+++ b/src/api/reserve/config/assets.config.ts
@@ -135,6 +135,12 @@ export const ASSETS_CONFIGS: Record<Chain, Partial<Record<AssetSymbol, AssetConf
       decimals: 6,
       address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
     },
+    AUSD: {
+      symbol: 'AUSD',
+      name: 'Agora USD',
+      decimals: 6,
+      address: '0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a',
+    },
   },
   [Chain.BITCOIN]: {
     BTC: {


### PR DESCRIPTION
# Description

Adds tracking for AUSD on mainnet

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only addition for a new tracked asset; no auth, payment, or core logic changes in this diff.
> 
> **Overview**
> Registers **AUSD** (Agora USD) on **Ethereum mainnet** in `ASSETS_CONFIGS`, using the same contract address and 6-decimal metadata as the existing Monad entry so reserve tracking and pricing can treat Ethereum-held AUSD like other USD-pegged stables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c2b719f3e0c874f9d72a92a2abc99575f37596a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->