### PR TITLE
docs: point agents to master context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Mento Analytics API Instructions
+
+For any protocol-level question that crosses beyond this API repo, first read
+the private `mento-master-context` router when the checkout is available:
+
+```text
+../mento-master-context/.agents/mento-context/README.md
+```
+
+This applies before broad repo searches for contracts, deployments, addresses,
+ABIs, live on-chain state, stable supply, reserve data, monitoring/data
+semantics, docs, the whitepaper, business model, or legal/risk framing. Load
+only the relevant master-context card(s), then return to this repo for API
+implementation details.
+
+This repo is source of truth for API code and cache behavior, not direct proof
+of current on-chain state. Verify current API output against the live endpoint
+when needed, and verify current chain values with RPC at an explicit block.
+When answering, mention which master-context card you used or state that the
+checkout was unavailable.


### PR DESCRIPTION
## Summary
- Add a root AGENTS.md pointer to the private mento-master-context router.
- Keep this repo as source of truth for local implementation details while routing cross-protocol questions to the compact context index first.

## Validation
- git diff --check
- local autoreview helper: no deterministic findings
- commit/push hooks ran where configured

## Ship Checklist
- [x] ship skill used
- [x] local review run
- [x] validation run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, API, or security behavior impact.
> 
> **Overview**
> Adds a root **`AGENTS.md`** so coding agents know how to work in this repo.
> 
> Agents should consult the private **`mento-master-context`** router (`../mento-master-context/.agents/mento-context/README.md`) **before** wide in-repo searches for protocol-wide topics (contracts, deployments, on-chain state, reserves, docs, legal/risk, etc.), then come back here for API implementation details.
> 
> The doc also states this repo is authoritative for **API code and cache behavior**, not live chain truth—verify via the live API and RPC at an explicit block when needed, and cite which context card was used (or that the checkout was missing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49bce80e97afb4b4da15fa77563e049ddc0aa230. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->