### PR TITLE
fix: guard exchange rate conversion against undefined currency

### DIFF
--- a/src/common/services/exchange-rates.service.ts
+++ b/src/common/services/exchange-rates.service.ts
@@ -118,6 +118,13 @@ export class ExchangeRatesService {
    * Get exchange rate for a specific currency
    */
   async getRate(currency: string): Promise<number> {
+    if (!currency) {
+      const error = new Error(`Invalid currency for rate lookup: ${currency}`);
+      this.logger.error(error.message);
+      Sentry.captureException(error, { level: 'error' });
+      throw error;
+    }
+
     const rates = await withRetry(() => this.fetchRates(), 'Failed to fetch exchange rates', {
       ...RETRY_CONFIGS.EXTERNAL_API,
       logger: this.logger,
@@ -138,6 +145,13 @@ export class ExchangeRatesService {
    * Convert amount from one currency to another via USD
    */
   async convert(amount: number, from: string, to: string): Promise<number> {
+    if (!from || !to) {
+      const error = new Error(`Invalid currency for conversion: from=${from}, to=${to}`);
+      this.logger.error(error.message);
+      Sentry.captureException(error, { level: 'error' });
+      throw error;
+    }
+
     const rates = await withRetry(() => this.fetchRates(), 'Failed to fetch exchange rates', {
       ...RETRY_CONFIGS.EXTERNAL_API,
       logger: this.logger,


### PR DESCRIPTION
## Problem

Sentry is reporting an escalating error on `GET /api/v1/reserve/stats`:

```
TypeError: Cannot read properties of undefined (reading 'toUpperCase')
  at ExchangeRatesService.convert (exchange-rates.service.ts)
```

`convert(amount, from, to)` calls `from.toUpperCase()` before validating `from`. When a stablecoin's fiat ticker resolves to `undefined`, the property access throws an opaque error mid-`Promise.all` in `StablecoinsService.getStablecoins()`.

The underlying ticker-derivation issue is already fixed on `main` (#84, slice-based extraction). This PR adds a defensive net so an undefined/empty currency produces an actionable, Sentry-captured error instead of a cryptic `toUpperCase` crash — and fails before the rates network call.

## Changes

- `convert()` — throw a descriptive `Invalid currency for conversion: from=… to=…` when `from`/`to` is falsy.
- `getRate()` — same guard for `currency` (identical `.toUpperCase()` footgun).

Behavior for valid input is unchanged; callers already wrap these in `withRetry` and degrade gracefully on failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive validation in a shared service; no change to happy-path conversion logic or external API behavior.
> 
> **Overview**
> Adds **early falsy checks** in `ExchangeRatesService` so `getRate` and `convert` never call `.toUpperCase()` on missing currency strings.
> 
> When `from`, `to`, or `currency` is undefined/empty, the service now throws a clear `Invalid currency…` error, logs it, reports to Sentry, and **returns before** the exchange-rates fetch. Valid inputs behave the same as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ef71483bcc3be9ce64bf05f9c32ae01a63d3fa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->